### PR TITLE
fix bug that save button not working

### DIFF
--- a/src/components/molecules/MultiSelect.tsx
+++ b/src/components/molecules/MultiSelect.tsx
@@ -96,9 +96,11 @@ const MultiSelect = <
     }
   };
 
+  const saveButtonId = `MultiSelect-SaveButton-value-${JSON.stringify(value)}`;
   const SaveButton = () => {
     return (
       <LoadingButton
+        id={saveButtonId}
         pending={isSaving}
         sx={{ ml: 1 }}
         onClick={async () => {
@@ -121,7 +123,6 @@ const MultiSelect = <
           onFocusOut();
         }
         setIsSelectFocused(false);
-        setMenuOpen(true);
       }}
     >
       <div className={styles.selectContainer}>
@@ -131,13 +132,20 @@ const MultiSelect = <
           multiple
           open={menuOpen}
           onOpen={() => setMenuOpen(true)}
-          onClose={(e, reason) => {
+          onClose={async (e, reason) => {
             if (
               reason === "escape" ||
               reason === "toggleInput" ||
               reason === "blur"
             ) {
               setMenuOpen(false);
+            }
+            const saveButton = document.getElementById(saveButtonId);
+
+            // @ts-expect-error I don't know how to resolve this
+            if (saveButton && e.relatedTarget === saveButton) {
+              await save();
+              setIsSelectFocused(false);
             }
           }}
           ChipProps={{


### PR DESCRIPTION
## What?
- fix bug that save button not working

## Why?
- bug fix

## Screenshot or video
- SaveButton 自体に問題はなく，Material-UI の Autocomplete のクリックイベントの広い方が特殊？であることが原因だった
![image](https://user-images.githubusercontent.com/72174933/114866286-55cb4080-9e2e-11eb-961e-98a65c3d94d8.png)

- ので，ひとまずクリックイベントに含まれていた情報から何をクリックしたのかを推定する形とした

