### PR TITLE
Use GitHub-hosted runners

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   hook:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Repository Dispatch

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   docker:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 300
 
     steps:


### PR DESCRIPTION
## What?
Use GitHub-hosted runners for CI

## Why?
Public repositories can use unlimited runners