### PR TITLE
Add confirmation when role is going to be deleted.

### DIFF
--- a/src/components/organisms/RolesPage.tsx
+++ b/src/components/organisms/RolesPage.tsx
@@ -16,6 +16,7 @@ import {
   SearchFormProps,
   TableProps,
   extractReasonFromFetchError,
+  confirm,
 } from "@dataware-tools/app-common";
 import AddCircle from "@mui/icons-material/AddCircle";
 import LoadingButton from "@mui/lab/LoadingButton";
@@ -203,6 +204,14 @@ export const RolesPage = (): JSX.Element => {
   };
 
   const onDeleteRole = async (roleId: number) => {
+    if (
+      !(await confirm({
+        title: "Are you sure you want to delete role?",
+        confirmMode: "delete",
+      }))
+    )
+      return;
+
     const prev = listRolesRes;
     const newLocalRoles = prev?.roles.filter((role) => role.role_id !== roleId);
     mutate(


### PR DESCRIPTION
## What?
- Add confirmation when role is going to be deleted.

## Why?
- Deleting role may have dengerous effect on dataware-tools

## See also
Resolves https://github.com/dataware-tools/dataware-tools/issues/88

## Screenshot or video
![ConfirmDeletingRole](https://user-images.githubusercontent.com/72174933/138669406-65e9f868-8ded-4a72-bd8f-18264c47b4dd.gif)

