### PR TITLE
Fix build config for symlinking app-common

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -31,6 +31,7 @@ module.exports = {
       ...config,
       resolve: {
         ...config.resolve,
+        symlinks:false,
         alias: {
           ...config.resolve.alias,
           "@emotion/core": toPath("node_modules/@emotion/react"),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "strict": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "esnext"
+    "target": "esnext",
+    "preserveSymlinks": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,4 +21,20 @@ export default defineConfig({
   cacheDir: "./.vite",
   assetsInclude: ["robots.txt"],
   build: { outDir: "./dist" + packageInfo.basePath },
+  resolve: {
+    preserveSymlinks: true,
+    // this option should be same with app-common peerDependencies
+    dedupe: [
+      "@auth0/auth0-react",
+      "@emotion/react",
+      "@emotion/styled",
+      "@mui/icons-material",
+      "@mui/lab",
+      "@mui/material",
+      "@mui/styles",
+      "oidc-react",
+      "react",
+      "react-dom",
+    ],
+  },
 });


### PR DESCRIPTION
## What?
Fix build config for symlinking app-common

## Why?
app-common をシンボリックリンクしたときに，コンポーネントの見た目が違うものになっていて，ヴィジュアルリグレッションテストが正しく行えないから

## See also
https://github.com/dataware-tools/app-data-browser-next/pull/278
